### PR TITLE
Alex/switch fixes

### DIFF
--- a/lib/handlers/sdp/MediaSection.js
+++ b/lib/handlers/sdp/MediaSection.js
@@ -186,6 +186,7 @@ class AnswerMediaSection extends MediaSection
 							opusFec,
 							opusDtx,
 							opusMaxPlaybackRate,
+							opusMaxAverageBitrate,
 							videoGoogleStartBitrate,
 							videoGoogleMaxBitrate,
 							videoGoogleMinBitrate
@@ -218,8 +219,12 @@ class AnswerMediaSection extends MediaSection
 								if (opusMaxPlaybackRate !== undefined)
 									codecParameters.maxplaybackrate = opusMaxPlaybackRate;
 
-								if(opusMaxAverageBitrate !== undefined)
-									codecParameters.maxaveragebitrate = opusMaxAverageBitrate;
+								if (opusMaxAverageBitrate !== undefined) {
+									// only set the given bitrate if the server does not specify, or the requested value is less than the servers
+									if (!codecParameters.maxaveragebitrate || codecParameters.maxaveragebitrate > opusMaxAverageBitrate) {
+										codecParameters.maxaveragebitrate = opusMaxAverageBitrate;
+									}
+								}
 
 								break;
 

--- a/lib/handlers/sdp/MediaSection.js
+++ b/lib/handlers/sdp/MediaSection.js
@@ -197,7 +197,6 @@ class AnswerMediaSection extends MediaSection
 						switch (codec.mimeType.toLowerCase())
 						{
 							case 'audio/opus':
-							{
 								if (opusStereo !== undefined)
 								{
 									offerCodec.parameters['sprop-stereo'] = opusStereo ? 1 : 0;
@@ -219,14 +218,15 @@ class AnswerMediaSection extends MediaSection
 								if (opusMaxPlaybackRate !== undefined)
 									codecParameters.maxplaybackrate = opusMaxPlaybackRate;
 
+								if(opusMaxAverageBitrate !== undefined)
+									codecParameters.maxaveragebitrate = opusMaxAverageBitrate;
+
 								break;
-							}
 
 							case 'video/vp8':
 							case 'video/vp9':
 							case 'video/h264':
 							case 'video/h265':
-							{
 								if (videoGoogleStartBitrate !== undefined)
 									codecParameters['x-google-start-bitrate'] = videoGoogleStartBitrate;
 
@@ -237,7 +237,6 @@ class AnswerMediaSection extends MediaSection
 									codecParameters['x-google-min-bitrate'] = videoGoogleMinBitrate;
 
 								break;
-							}
 						}
 					}
 


### PR DESCRIPTION
Let me know what you think about the `maxaveragebitrate` logic. This should prevent anything getting set higher than what the server supports. Without this, the server just accepts and bitrate the client sets.